### PR TITLE
Fix LuaState#push_thread and add specs

### DIFF
--- a/spec/lua_state_spec.cr
+++ b/spec/lua_state_spec.cr
@@ -262,4 +262,27 @@ describe Luajit::LuaState do
       end
     end
   end
+
+  describe "#push_thread" do
+    it "pushes the current thread" do
+      Luajit.run do |state|
+        state.push_thread.should eq(Luajit::LuaState::ThreadStatus::Main)
+        state.is_thread?(-1).should be_true
+
+        SpecHelper.assert_stack_size!(state, 1)
+      end
+    end
+
+    it "pushes a coroutine" do
+      Luajit.run do |state|
+        coroutine = state.new_thread
+        state.pop(1) # remove thread pushed by `new_thread`
+
+        coroutine.push_thread.should eq(Luajit::LuaState::ThreadStatus::Coroutine)
+        coroutine.is_thread?(-1).should be_true
+
+        SpecHelper.assert_stack_size!(coroutine, 1)
+      end
+    end
+  end
 end

--- a/src/luajit/lua_state.cr
+++ b/src/luajit/lua_state.cr
@@ -932,9 +932,12 @@ module Luajit
       LibLuaJIT.lua_pushcclosure(self, proc, 1)
     end
 
-    # Pushes thread represented by *x* onto the stack, returns `ThreadStatus`
-    def push_thread(x : LuaState) : ThreadStatus
-      if LibLuaJIT.lua_pushthread(x) == 1
+    # Pushes `self` onto its own stack and returns its thread status
+    #
+    # `ThreadStatus::Main` is returned when `self` represents the main
+    # thread, otherwise `ThreadStatus::Coroutine` is returned.
+    def push_thread : ThreadStatus
+      if LibLuaJIT.lua_pushthread(self) == 1
         ThreadStatus::Main
       else
         ThreadStatus::Coroutine


### PR DESCRIPTION
## Summary
- fix `LuaState#push_thread` so it pushes `self`
- test pushing the current thread
- test pushing a coroutine

## Testing
- `crystal spec --order random --fail-fast`


------
https://chatgpt.com/codex/tasks/task_e_684d6c8084648325b0c74d232c9781a2