### PR TITLE
Fix typo in lua_state comment

### DIFF
--- a/src/luajit/lua_state.cr
+++ b/src/luajit/lua_state.cr
@@ -19,7 +19,7 @@ module Luajit
 
     # :nodoc:
     #
-    # Sets the *state* pointer address inside it's own registry
+    # Sets the *state* pointer address inside its own registry
     #
     # Used with `#get_registry_address` for tracking whether a LuaState
     # instance or thread is part of a parent LuaState instance


### PR DESCRIPTION
## Summary
- fix typo in comment describing registry address setup

## Testing
- `crystal spec -v`

------
https://chatgpt.com/codex/tasks/task_e_684d71a0042883259e280633fb636612