### PR TITLE
Fix numeric index conversion in to_a

### DIFF
--- a/spec/lua_state_spec.cr
+++ b/spec/lua_state_spec.cr
@@ -171,6 +171,22 @@ describe Luajit::LuaState do
         SpecHelper.assert_stack_size!(state, 1)
       end
     end
+
+    it "ignores non-array keys" do
+      Luajit.run do |state|
+        state.execute! <<-'LUA'
+        b = {1, 2}
+        b[3.5] = 7
+        b["foo"] = 9
+        LUA
+        state.get_global("b")
+        arr = state.to_a(-1)
+
+        arr.map(&.as_f.to_i).should eq([1, 2])
+
+        SpecHelper.assert_stack_size!(state, 1)
+      end
+    end
   end
 
   describe "#push_fn_closure" do

--- a/src/luajit/lua_state.cr
+++ b/src/luajit/lua_state.cr
@@ -1401,7 +1401,7 @@ module Luajit
       Array(LuaAny).new(total).tap do |arr|
         total.times do |n|
           i = n + 1
-          if value = hash[i]?
+          if value = hash[i.to_f]?
             arr << value
           else
             break


### PR DESCRIPTION
## Summary
- convert index to Float64 in `LuaState#to_a`
- add spec for tables with mixed keys

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_684d71a27f0083259a1ecfeab5d95a49