### PR TITLE
Fix is_relative_to return type

### DIFF
--- a/src/wrappers/path.lua
+++ b/src/wrappers/path.lua
@@ -22,7 +22,7 @@
 ---@field parents fun(self): Path[]
 ---@field parts fun(self): string[]
 ---@field relative_to fun(self, base: Path|string): Path
----@field is_relative_to fun(self, base: Path|string): Path?
+---@field is_relative_to fun(self, base: Path|string): boolean
 ---@field root fun(self): Path?
 ---@field sibling fun(self, name: Path|string): Path
 ---@field stem fun(self): string


### PR DESCRIPTION
## Summary
- fix annotation for `is_relative_to` to return boolean

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_684d71d0b4248325b0f0272c2f42f68c